### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -21,7 +21,7 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  "nxCloudId": "68c1bb4900ebb55905b134fd",
+  "nxCloudId": "698c11aff4f042309a7c7186",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/698c11a2f4f042309a7c7180/workspaces/698c11aff4f042309a7c7186

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.